### PR TITLE
Better test for #44.

### DIFF
--- a/core-tests.r
+++ b/core-tests.r
@@ -7436,7 +7436,7 @@ functions/control/any.r
 ]
 functions/control/apply.r
 ; bug#44
-[value? try [apply type?/word []]]
+[error? try [apply 'type?/word []]]
 functions/control/attempt.r
 ; bug#41
 [none? attempt [1 / 0]]


### PR DESCRIPTION
APPLY should fail when you try to pass it a path, so the result
should be an error, not just any value. Also, the path needed a quote
to be a path - without, APPLY failed because it didn't have enough
parameters to execute, since TYPE?/word consumed the block.
