### PR TITLE
Compatibility fixes

### DIFF
--- a/core-tests.r
+++ b/core-tests.r
@@ -27,14 +27,12 @@ datatypes/binary.r
 [#{00} == to binary! "^(00)"]
 ; minimum
 [binary? #{}]
-#r2only
 ; alternative literal representation
 [#{} == #[binary! #{}]]
 datatypes/bitset.r
 [bitset? make bitset! "a"]
 [not bitset? 1]
 [bitset! = type? make bitset! "a"]
-#r2only
 ; minimum, literal representation
 [bitset? #[bitset! #{}]]
 datatypes/block.r
@@ -43,7 +41,6 @@ datatypes/block.r
 [block! = type? [1]]
 ; minimum
 [block? []]
-#r2only
 ; alternative literal representation
 [[] == #[block! []]]
 [[] == make block! 0]
@@ -200,14 +197,11 @@ datatypes/char.r
 ; maximum
 [char? #"^(ff)"]
 datatypes/closure.r
-#r3only
 [closure? closure [] ["OK"]]
-#r3only
 [not closure? 1]
 #r3only
 [closure! = type? closure [] ["OK"]]
 ; minimum
-#r3only
 [closure? closure [] []]
 ; literal form
 #r3only
@@ -481,7 +475,6 @@ datatypes/closure.r
 		2 = c
 	]
 ]
-#r3only
 ; bug#1528
 [closure? closure [self] []]
 datatypes/datatype.r
@@ -492,6 +485,10 @@ datatypes/datatype.r
 [datatype? bitset!]
 [datatype? block!]
 [datatype? char!]
+#r3
+[datatype? closure!]  ; closure! =? function! in R2/Forward, R2 2.7.7+
+#r3only
+[datatype? command!]
 [datatype? datatype!]
 [datatype? date!]
 [datatype? decimal!]
@@ -500,7 +497,13 @@ datatypes/datatype.r
 [datatype? event!]
 [datatype? file!]
 [datatype? function!]
+#r3
+[datatype? get-path!]  ; get-path! =? path! in R2/Forward, R2 2.7.7+
 [datatype? get-word!]
+#r3only
+[datatype? gob!]
+#r3only
+[datatype? handle!]
 #r2only
 [datatype? hash!]
 [datatype? image!]
@@ -512,8 +515,8 @@ datatypes/datatype.r
 [datatype? lit-path!]
 [datatype? lit-word!]
 [datatype? logic!]
-#r3only
-[datatype? map!]
+#r3
+[datatype? map!]  ; map! =? hash! in R2/Forward, R2 2.7.7+
 #r3only
 [datatype? module!]
 [datatype? money!]
@@ -539,8 +542,8 @@ datatypes/datatype.r
 [datatype? tag!]
 [datatype? time!]
 [datatype? tuple!]
-#r3only
-[datatype? typeset!]
+#r3
+[datatype? typeset!]  ; typeset! =? block! in R2/Forward, R2 2.7.7+
 [datatype? unset!]
 [datatype? url!]
 #r3only
@@ -649,12 +652,9 @@ datatypes/email.r
 [email? me@here.com]
 [not email? 1]
 [email! = type? me@here.com]
-#r2only
 ; "minimum"
 [email? #[email! ""]]
-#r2only
 [strict-equal? #[email! ""] make email! 0]
-#r2only
 [strict-equal? #[email! ""] to email! ""]
 datatypes/error.r
 [error? try [1 / 0]]
@@ -1105,7 +1105,6 @@ datatypes/file.r
 [file! = type? %myscript.r]
 ; minimum
 [file? %""]
-#r2only
 [%"" == #[file! ""]]
 [%"" == make file! 0]
 [%"" == to file! ""]
@@ -1536,13 +1535,26 @@ datatypes/lit-word.r
 	a-value: first ['a]
 	strict-equal? to word! :a-value do reduce [:a-value]
 ]
-; bug#1342
+; bug#1477
 [word? '/]
+[word? '//]
+[word? '///]
+; bug#1342
 [word? '<]
 [word? '>]
 [word? '<=]
 [word? '>=]
 [word? '<>]
+datatypes/get-word.r
+; bug#1477
+[get-word? first [:/]]
+[get-word? first [://]]
+[get-word? first [:///]]
+datatypes/set-word.r
+; bug#1477
+[set-word? first [/:]]
+[set-word? first [//:]]
+[set-word? first [///:]]
 datatypes/logic.r
 [logic? true]
 [logic? false]
@@ -1563,17 +1575,17 @@ datatypes/logic.r
 [true = to logic! "f"]
 ["true" = mold true]
 ["false" = mold false]
-datatypes/map.r
-#r3only
+datatypes/map.r  ; map! =? hash! in R2/Forward, R2 2.7.7+
+#r3
 [empty? make map! []]
-#r3only
+#r3
 [empty? make map! 4]
 #r3only
 ; The length of a map is the number of key/value pairs it holds.
-[2 == length? make map! [a 1 b 2]]
-#r3only
+[2 == length? make map! [a 1 b 2]]  ; 4 in R2, R2/Forward
+#r3
 [m: make map! [a 1 b 2] 1 == m/a]
-#r3only
+#r3
 [m: make map! [a 1 b 2] 2 == m/b]
 #r3only
 [m: make map! [a 1 b 2] none? m/c]
@@ -1582,9 +1594,9 @@ datatypes/map.r
 #r3only
 ; Maps contain key/value pairs and must be created from blocks of even length.
 [error? try [make map! [1]]]
-#r3only
+#r3
 [empty? clear make map! [a 1 b 2]]
-#r3only
+#r3
 [empty? clear make map! [a 1 b 2]]
 #r3only
 #r3crash
@@ -1608,6 +1620,21 @@ datatypes/module.r
 	]
 	var: 2
 	1 == a-module/var
+]
+#r3only
+; import test
+[
+	a-module: make module! [
+		[
+			exports: [var]
+		]
+
+		[
+			var: 2
+		]
+	]
+	import a-module
+	2 == var
 ]
 #r3only
 ; import test
@@ -1848,6 +1875,8 @@ datatypes/none.r
 [none = #[none]]
 ; bug#845
 [none = #[none!]]
+#r3only
+[none = #]
 [none = make none! none]
 [none = to none! none]
 [none = to none! 1]
@@ -1858,7 +1887,6 @@ datatypes/object.r
 [object! = type? make object! [x: 1]]
 ; minimum
 [object? make object! []]
-#r2only
 ; literal form
 [object? #[object! []]]
 ; local words
@@ -1916,12 +1944,10 @@ datatypes/pair.r
 [not pair? 1]
 [pair! = type? 1x2]
 [1x1 = make pair! 1]
-#r2only
 [1x2 = make pair! [1 2]]
 [1x1 = to pair! 1]
 ; bug#17
 [error? try [to pair! [0.4]]]
-#r2only
 [1x2 = to pair! [1 2]]
 ["1x1" = mold 1x1]
 ; minimum
@@ -1933,7 +1959,6 @@ datatypes/paren.r
 [not paren? 1]
 ; minimum
 [paren! = type? first [()]]
-#r2only
 ; alternative literal form
 [strict-equal? first [()] first [#[paren! []]]]
 [strict-equal? first [()] make paren! 0]
@@ -2185,7 +2210,6 @@ datatypes/string.r
 [string! = type? "ahoj"]
 ; minimum
 [string? ""]
-#r2only
 ; alternative literal form
 ["" == #[string! ""]]
 ["" == make string! 0]
@@ -2328,7 +2352,6 @@ datatypes/string.r
 ["^(del)" = "^(7f)"]
 ["^^" = "^(5E)"]
 ["^"" = "^(22)"]
-#r2only
 ["ahoj" = #[string! "ahoj"]]
 ["1" = to string! 1]
 [{""} = mold ""]
@@ -2345,12 +2368,9 @@ datatypes/tag.r
 [tag? <tag>]
 [not tag? 1]
 [tag! = type? <tag>]
-#r2only
 ; minimum
 [tag? #[tag! ""]]
-#r2only
 [strict-equal? #[tag! ""] make tag! 0]
-#r2only
 [strict-equal? #[tag! ""] to tag! ""]
 ["<tag>" == mold <tag>]
 datatypes/typeset.r
@@ -2358,28 +2378,64 @@ datatypes/typeset.r
 [datatype? any-block!]
 #r3only
 [typeset? any-block!]
+#r3
+[typeset? to-typeset any-block!]
 #r2only
 [datatype? any-function!]
 #r3only
 [typeset? any-function!]
+#r3
+[typeset? to-typeset any-function!]
+#r3
+[typeset? any-path!]
+#r3
+[typeset? to-typeset any-path!]
+#r3
+[typeset? any-object!]
+#r3
+[typeset? to-typeset any-object!]
 #r2only
 [datatype? any-string!]
 #r3only
 [typeset? any-string!]
+#r3
+[typeset? to-typeset any-string!]
 #r2only
 [datatype? any-word!]
 #r3only
 [typeset? any-word!]
+#r3
+[typeset? to-typeset any-word!]
+#r3
+[typeset? immediate!]
+#r3
+[typeset? to-typeset immediate!]
+#r3
+[typeset? internal!]
+#r3
+[typeset? to-typeset internal!]
 #r2only
 [datatype? number!]
 #r3only
 [typeset? number!]
+#r3
+[typeset? to-typeset number!]
+#r3
+[typeset? scalar!]
+#r3
+[typeset? to-typeset scalar!]
 #r2only
 [datatype? series!]
 #r3only
 [typeset? series!]
+#r3
+[typeset? to-typeset series!]
 #r3only
 [typeset? make typeset! [integer! none!]]
+#r3
+[typeset? make typeset! reduce [integer! none!]]
+#r3
+[typeset? to-typeset [integer! none!]]
 #r3only
 [typeset! = type? series!]
 datatypes/time.r
@@ -2443,12 +2499,9 @@ datatypes/url.r
 [url? http://www.fm.tul.cz/~ladislav/rebol]
 [not url? 1]
 [url! = type? http://www.fm.tul.cz/~ladislav/rebol]
-#r2only
 ; minimum; alternative literal form
 [url? #[url! ""]]
-#r2only
 [strict-equal? #[url! ""] make url! 0]
-#r2only
 [strict-equal? #[url! ""] to url! ""]
 ["http://" = mold http://]
 ["http://a%2520b" = mold http://a%2520b]
@@ -2659,12 +2712,10 @@ functions/comparison/equalq.r
 ; Uses FUNC instead of make function! so the test is compatible.
 [not equal? func [][] func [][]]
 ; reflexivity test for closure!
-; Uses CLOSURE to make the test compatible. On todo list for R2/Forward.
-#r3
+; Uses CLOSURE to make the test compatible.
 [equal? a-value: closure [][] :a-value]
 ; No structural equivalence for closure!
-; Uses CLOSURE to make the test compatible. On todo list for R2/Forward.
-#r3
+; Uses CLOSURE to make the test compatible.
 [not equal? closure [][] closure [][]]
 [equal? a-value: #{00} a-value]
 ; binary!
@@ -4010,13 +4061,11 @@ functions/comparison/sameq.r
 ; no structural equality for function!
 [not same? func [] [] func [] []]
 ; reflexivity test for closure!
-#r3
 [
 	a-value: closure [] []
 	same? :a-value :a-value
 ]
 ; no structural equality for closure!
-#r3
 [not same? closure [] [] closure [] []]
 ; reflexivity test for native!
 [same? :all :all]
@@ -4029,15 +4078,6 @@ functions/comparison/sameq.r
 ]
 ; no structural equality for function!
 [not same? func [] [] func [] []]
-; reflexivity test for closure!
-#r3
-[
-	a-value: closure [] []
-	same? :a-value :a-value
-]
-; no structural equality for closure!
-#r3
-[not same? closure [] [] closure [] []]
 ; binary!
 [not same? #{00} #{00}]
 ; binary versus bitset
@@ -4498,13 +4538,11 @@ functions/comparison/strict-equalq.r
 ; no structural equality for function!
 [not strict-equal? func [] [] func [] []]
 ; reflexivity test for closure!
-#r3
 [
 	a-value: closure [] []
 	strict-equal? :a-value :a-value
 ]
 ; no structural equality for closure!
-#r3
 [not strict-equal? closure [] [] closure [] []]
 ; binary!
 [strict-equal? #{00} #{00}]
@@ -9390,7 +9428,7 @@ functions/series/emptyq.r
 	clear head blk
 	empty? blk
 ]
-#r3
+#r3only
 [empty? none]
 functions/series/exclude.r
 [empty? exclude [1 2] [2 1]]
@@ -9748,7 +9786,7 @@ functions/series/last.r
 functions/series/lengthq.r
 ; bug#1626: "Allow LENGTH? to take none as an argument, return none"
 ; bug#1688: "LENGTH? NONE returns TRUE" (should return NONE)
-#r3
+#r3only
 [none? length? none]
 functions/series/next.r
 [
@@ -10083,9 +10121,9 @@ functions/convert/load.r
 ; load/next
 #r2only
 [block? load/next "1"]
-; bug#1711
+; bug#1703  bug#1711
 #r3only
-[try/except [block? load/next "1"] [true]]
+[error? try [load/next "1"]]
 ; bug#1122
 [
 	any [
@@ -10114,6 +10152,7 @@ functions/convert/mold.r
 ]
 ; closure mold
 ; bug#23
+#r3only
 [
 	c: closure [a] [print a]
 	equal? "make closure! [[a][print a]]" mold :c
@@ -10372,7 +10411,7 @@ datatypes/percent.r
 #r3crash
 [error? try [repeat n 200 [try [close open open join tcp://localhost: n]]] true]
 ; bug#1651: "FILE-TYPE? should return NONE for unknown types"
-#r3
+#r3only
 [none? file-type? %foo.0123456789bar0123456789]
 ; bug#1678: "Can we add CRC-32 as a checksum method?"
 #r3only


### PR DESCRIPTION
Some fixes to update test compatibility:
- Got rid of `#r2only` for R3-supported alternate literal forms.
- Added `#r3only` test for `#` none literal.
- Fake closures are in R2 proper since 2.7.7, no tag needed.
- Made closure mold test `#r3only`.
- Added missing `#r3only` datatypes.
- Added fake R2/Forward datatypes as `#r3`.
- Split out bug#1477 from bug#1432.
- Changed `#r3only` to `#r3` for successfully faked `map!` stuff.
- Added `#r3` tests for sucessfully faked `typeset!` stuff.
- Changed `none` passthrough tests from `#r3` to `#r3only`.
- Made bug#1711 test less ambiguous.
- Made `file-type?` test `#r3only` - it's not planned to backport.

Even though the fake datatype stuff has been included in R2 2.7.7+
it doesn't work well enough to merit testing for it in R2, so those
are `#r3` tagged. The closure stuff works great though, so the tags
are off for those tests where applicable.

The none passthrough stuff affects natives, so it's against policy
to change those in R2/Forward. Codecs aren't planned either, so
no `file-type?` function.
